### PR TITLE
Support basename querying in functions

### DIFF
--- a/tools/hat.py
+++ b/tools/hat.py
@@ -138,6 +138,11 @@ class AttributeDict(OrderedDict):
     def names(self):
         return list(self.keys())
 
+    def __getitem__(self, key):
+        for k, v in self.items():
+            if k.startswith(key):
+                return v
+        return OrderedDict.__getitem__(key)
 
 def load(hat_path):
     """ Creates a class with static functions based on the function descriptions in a HAT package

--- a/tools/test/test_hat.py
+++ b/tools/test/test_hat.py
@@ -42,8 +42,17 @@ class HAT_test(unittest.TestCase):
             B = np.random.rand(16, 16).astype(np.float32)
             B_ref = B + A
 
-            test_function = hat_package[function.name]
+            # find the function by basename
+            test_function = hat_package["test_function"]
             test_function(A, B)
+
+            # check for correctness
+            np.testing.assert_allclose(B, B_ref)
+
+            # find the function by actual name
+            B_ref = B + A
+            test_function1 = hat_package[function.name]
+            test_function1(A, B)
 
             # check for correctness
             np.testing.assert_allclose(B, B_ref)


### PR DESCRIPTION
Support querying functions by basename in a dynamically loaded HAT package.

Emit time:
```python
package.add(..., basename="myfunc")
```

Load time:
```python
hat_package = load("mypackage.dyn.hat")
myfunc = hat_package["myfunc"]
```