### PR TITLE
Fix regression in accessing target_file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Unittest
       run: |
         python -m pip install -r tools/test/requirements.txt
-        python -m pip uninstall -y hatlib
         python -m unittest discover tools/test
     - name: Build whl
       run: |

--- a/tools/hat_file.py
+++ b/tools/hat_file.py
@@ -453,9 +453,11 @@ class HATFile:
         root_table.add(CompiledWith.TableName, self.compiled_with.to_table())
         root_table.add(Declaration.TableName, self.declaration.to_table())
         with open(filepath, "w") as out_file:
-            out_file.write(self.HATPrologue.format(self.name))
+            # MSVC does not allow "." in macro definitions
+            name = self.name.replace(".", "_")
+            out_file.write(self.HATPrologue.format(name))
             out_file.write(tomlkit.dumps(root_table))
-            out_file.write(self.HATEpilogue.format(self.name))
+            out_file.write(self.HATEpilogue.format(name))
 
     @staticmethod
     def Deserialize(filepath):

--- a/tools/hat_to_dynamic.py
+++ b/tools/hat_to_dynamic.py
@@ -60,7 +60,7 @@ def linux_create_dynamic_package(input_hat_path, input_hat_binary_path, output_h
     # create new HAT binary
     prefix, _ = os.path.splitext(output_hat_path)
     output_hat_binary_path = prefix + ".so"
-    libraries = " ".join([d["target_file"] for d in hat_file.dependencies.dynamic])
+    libraries = " ".join([d.target_file for d in hat_file.dependencies.dynamic])
     os.system(f'gcc -shared -fPIC -o "{output_hat_binary_path}" "{inline_obj_path}" "{input_hat_binary_path}" {libraries}')
 
     # create new HAT file
@@ -116,7 +116,7 @@ def windows_create_dynamic_package(input_hat_path, input_hat_binary_path, output
         function_names = [f.name for f in function_descriptions]
         exports = " -EXPORT:".join(function_names)
 
-        libraries = " ".join([d["target_file"] for d in hat_file.dependencies.dynamic])
+        libraries = " ".join([d.target_file for d in hat_file.dependencies.dynamic])
         linker_command_line = f'link.exe -dll -FORCE:MULTIPLE -EXPORT:{exports} -out:out.dll dllmain.obj "{input_hat_binary_path}" {libraries}'
         os.system(linker_command_line)
         shutil.copyfile("out.dll", output_hat_binary_path)

--- a/tools/hat_to_dynamic.py
+++ b/tools/hat_to_dynamic.py
@@ -61,7 +61,7 @@ def linux_create_dynamic_package(input_hat_path, input_hat_binary_path, output_h
     # create new HAT binary
     prefix, _ = os.path.splitext(output_hat_path)
     suffix = token_hex(4) # always create a new dll (avoids cases where dll is already loaded)
-    output_hat_binary_path = f"{prefix}{suffix}.so"
+    output_hat_binary_path = f"{prefix}_{suffix}.so"
     libraries = " ".join([d.target_file for d in hat_file.dependencies.dynamic])
     os.system(f'gcc -shared -fPIC -o "{output_hat_binary_path}" "{inline_obj_path}" "{input_hat_binary_path}" {libraries}')
 
@@ -113,7 +113,7 @@ def windows_create_dynamic_package(input_hat_path, input_hat_binary_path, output
         # create the new HAT binary dll
         suffix = token_hex(4) # always create a new dll (avoids case where dll is already loaded)
         prefix, _ = os.path.splitext(output_hat_path)
-        output_hat_binary_path = f"{prefix}{suffix}.dll"
+        output_hat_binary_path = f"{prefix}_{suffix}.dll"
 
         function_descriptions = hat_file.functions
         function_names = [f.name for f in function_descriptions]

--- a/tools/hat_to_dynamic.py
+++ b/tools/hat_to_dynamic.py
@@ -22,6 +22,7 @@ import sys
 import os
 import argparse
 import shutil
+from secrets import token_hex
 
 if __package__:
     from .hat_file import HATFile
@@ -59,7 +60,8 @@ def linux_create_dynamic_package(input_hat_path, input_hat_binary_path, output_h
 
     # create new HAT binary
     prefix, _ = os.path.splitext(output_hat_path)
-    output_hat_binary_path = prefix + ".so"
+    suffix = token_hex(4) # always create a new dll (avoids cases where dll is already loaded)
+    output_hat_binary_path = f"{prefix}{suffix}.so"
     libraries = " ".join([d.target_file for d in hat_file.dependencies.dynamic])
     os.system(f'gcc -shared -fPIC -o "{output_hat_binary_path}" "{inline_obj_path}" "{input_hat_binary_path}" {libraries}')
 
@@ -109,8 +111,9 @@ def windows_create_dynamic_package(input_hat_path, input_hat_binary_path, output
         os.system(f'cl.exe /I"{os.path.dirname(input_hat_path)}" /Fodllmain.obj /c dllmain.cpp')
 
         # create the new HAT binary dll
+        suffix = token_hex(4) # always create a new dll (avoids case where dll is already loaded)
         prefix, _ = os.path.splitext(output_hat_path)
-        output_hat_binary_path = prefix + ".dll"
+        output_hat_binary_path = f"{prefix}{suffix}.dll"
 
         function_descriptions = hat_file.functions
         function_names = [f.name for f in function_descriptions]


### PR DESCRIPTION
Introduced during the migration from `toml` to `HATFile`, we still need it in other tools so keeping the toml dependency for now. 

Generate a unique .so/.dll name to support repeated builds and loads in a jupyter notebook (ctypes has no good unload story.)