### PR TITLE
Create a static .lib/.a HAT package from a static .obj/.o HAT package

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -37,11 +37,30 @@ Usage:
 
 usage: hatlib.hat_to_dynamic [-h] input_hat_path output_hat_path
 
-Creates a dynamically-linked HAT package from a statically-linked HAT package. Example: python hat_to_dynamic.py input.hat output.hat
+Creates a dynamically-linked HAT package from a statically-linked HAT package. Example: hatlib.hat_to_dynamic input.hat output.hat
 
 positional arguments:
   input_hat_path   Path to the existing HAT file, which represents a statically-linked HAT package
   output_hat_path  Path to the new HAT file, which will represent a dynamically-linked HAT package
+
+optional arguments:
+  -h, --help       show this help message and exit
+```
+
+## hatlib.hat_to_lib
+A tool that converts a HAT package with .obj/.o into a HAT package with a .lib/.a
+
+Usage:
+
+```shell
+> hatlib.hat_to_lib --help
+usage: hatlib.hat_to_dynamic [-h] input_hat_path output_hat_path
+
+Creates a statically-linked HAT package with a .lib/.a from a statically-linked HAT package with an .obj/.o. Example: hatlib.hat_to_lib input.hat output.hat
+
+positional arguments:
+  input_hat_path   Path to the existing HAT file, which represents a statically-linked HAT package with an .obj/.o
+  output_hat_path  Path to the new HAT file, which will represent a statically-linked HAT package with a .lib/.a
 
 optional arguments:
   -h, --help       show this help message and exit
@@ -75,7 +94,7 @@ usage: benchmark_hat_package.py [-h] [--store_in_hat]
                                 [--input_sets_minimum_size_MB INPUT_SETS_MINIMUM_SIZE_MB]
                                 path_to_hat_package
 
-Benchmarks each function in a HAT package and estimates its duration. Example: benchmark_hat_package.py <hat_path>
+Benchmarks each function in a HAT package and estimates its duration. Example: hatlib.benchmark_hat <hat_path>
 
 positional arguments:
   hat_path   Path to the HAT file

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -2,4 +2,6 @@ from .hat import *
 from .hat_file import *
 from .hat_package import *
 from .hat_to_dynamic import *
+from .hat_to_lib import *
 from .benchmark_hat_package import run_benchmark
+from .platform_utilities import *

--- a/tools/benchmark_hat_package.py
+++ b/tools/benchmark_hat_package.py
@@ -190,7 +190,7 @@ def main(argv):
     arg_parser = argparse.ArgumentParser(
         description="Benchmarks each function in a HAT package and estimates its duration.\n"
         "Example:\n"
-        "    benchmark_hat_package.py <hat_path>\n")
+        "    hatlib.benchmark_hat_package <hat_path>\n")
 
     arg_parser.add_argument("hat_path",
         help="Path to the HAT file",

--- a/tools/hat_to_dynamic.py
+++ b/tools/hat_to_dynamic.py
@@ -43,7 +43,7 @@ def get_platform():
 
 
 def linux_create_dynamic_package(input_hat_path, input_hat_binary_path, output_hat_path, hat_file):
-    """Creates a dynamic HAT (.so) from a static HAT (.obj) on a Linux platform"""
+    """Creates a dynamic HAT (.so) from a static HAT (.o) on a Linux platform"""
     # Confirm that this is a static hat library
     _, extension = os.path.splitext(input_hat_binary_path)
     if extension not in [".o", ".a"]:
@@ -52,7 +52,7 @@ def linux_create_dynamic_package(input_hat_path, input_hat_binary_path, output_h
     # Create a C source file to resolve inline functions defined in the static HAT package
     include_path = os.path.dirname(input_hat_binary_path)
     inline_c_path = os.path.join(include_path, "inline.c")
-    inline_obj_path = os.path.join(include_path, "inline.obj")
+    inline_obj_path = os.path.join(include_path, "inline.o")
     with open(inline_c_path, "w") as f:
         f.write(f"#include <{os.path.basename(input_hat_path)}>")
     # compile it separately so that we can suppress the warnings about the missing terminating ' character
@@ -66,6 +66,7 @@ def linux_create_dynamic_package(input_hat_path, input_hat_binary_path, output_h
     os.system(f'gcc -shared -fPIC -o "{output_hat_binary_path}" "{inline_obj_path}" "{input_hat_binary_path}" {libraries}')
 
     # create new HAT file
+    hat_file.dependencies.dynamic = [] # previous dependencies are now part of the binary
     hat_file.dependencies.link_target = os.path.basename(output_hat_binary_path)
     hat_file.Serialize(output_hat_path)
 
@@ -125,6 +126,7 @@ def windows_create_dynamic_package(input_hat_path, input_hat_binary_path, output
         shutil.copyfile("out.dll", output_hat_binary_path)
 
         # create new HAT file
+        hat_file.dependencies.dynamic = [] # previous dependencies are now part of the binary
         hat_file.dependencies.link_target = os.path.basename(output_hat_binary_path)
         hat_file.Serialize("out.hat")
         shutil.copyfile("out.hat", output_hat_path)

--- a/tools/platform_utilities.py
+++ b/tools/platform_utilities.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+
+def get_platform():
+    """Returns the current platform: Linux, Windows, or OS X"""
+    
+    if sys.platform.startswith("linux"):
+        return "Linux"
+    if sys.platform == "win32":
+        return "Windows"
+    if sys.platform == "darwin":
+        return "OS X"
+
+    sys.exit(f"ERROR: Unsupported operating system: {sys.platform}")
+
+def windows_ensure_compiler_in_path():
+    """Ensures that PATH contains the cl.exe compiler from Microsoft Visual Studio.
+    Prompts the user if not found."""
+    import vswhere
+    vs_path = vswhere.get_latest_path()
+    if not vs_path:
+        sys.exit("ERROR: Could not find Visual Studio, please ensure that you have Visual Studio installed")
+
+    # Check if cl.exe is in PATH
+    if os.system("cl.exe"): # returns 0 if found, !0 otherwise
+        vcvars_script_path = os.path.join(vs_path, r"VC\Auxiliary\Build\vcvars64.bat")
+        sys.exit(f'ERROR: Could not find cl.exe, please run "{vcvars_script_path}" (including quotes) to setup your command prompt')

--- a/tools/platform_utilities.py
+++ b/tools/platform_utilities.py
@@ -1,18 +1,32 @@
 #!/usr/bin/env python3
 
+import os
 import sys
+
+if __package__:
+    from .hat_file import OperatingSystem
+else:
+    from hat_file import OperatingSystem
 
 def get_platform():
     """Returns the current platform: Linux, Windows, or OS X"""
     
     if sys.platform.startswith("linux"):
-        return "Linux"
+        return OperatingSystem.Linux
     if sys.platform == "win32":
-        return "Windows"
+        return OperatingSystem.Windows
     if sys.platform == "darwin":
-        return "OS X"
+        return OperatingSystem.MacOS
 
     sys.exit(f"ERROR: Unsupported operating system: {sys.platform}")
+
+
+def linux_ensure_compiler_in_path():
+    """Ensures that PATH contains the gcc compiler.
+    Prompts the user if not found."""
+    if os.system("gcc"): # returns 0 if found, !0 otherwise
+        sys.exit(f'ERROR: Could not find gcc, please install gcc before continuing')
+
 
 def windows_ensure_compiler_in_path():
     """Ensures that PATH contains the cl.exe compiler from Microsoft Visual Studio.
@@ -26,3 +40,11 @@ def windows_ensure_compiler_in_path():
     if os.system("cl.exe"): # returns 0 if found, !0 otherwise
         vcvars_script_path = os.path.join(vs_path, r"VC\Auxiliary\Build\vcvars64.bat")
         sys.exit(f'ERROR: Could not find cl.exe, please run "{vcvars_script_path}" (including quotes) to setup your command prompt')
+
+
+def ensure_compiler_in_path():
+    platform = get_platform()
+    if platform == OperatingSystem.Windows:
+        windows_ensure_compiler_in_path()
+    else:
+        linux_ensure_compiler_in_path()

--- a/tools/platform_utilities.py
+++ b/tools/platform_utilities.py
@@ -24,7 +24,7 @@ def get_platform():
 def linux_ensure_compiler_in_path():
     """Ensures that PATH contains the gcc compiler.
     Prompts the user if not found."""
-    if os.system("gcc"): # returns 0 if found, !0 otherwise
+    if os.system("gcc --version"): # returns 0 if found, !0 otherwise
         sys.exit(f'ERROR: Could not find gcc, please install gcc before continuing')
 
 

--- a/tools/test/test_hat.py
+++ b/tools/test/test_hat.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from hat import load
 from hat_to_dynamic import create_dynamic_package
-from hat_to_lib import create_static_lib_package
+from hat_to_lib import create_static_package
 
 class HAT_test(unittest.TestCase):
 
@@ -33,7 +33,7 @@ class HAT_test(unittest.TestCase):
             package.build(name=package_name, output_dir="test_acccgen", mode=mode)
 
             create_dynamic_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.dyn.hat")
-            create_static_library_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.lib.hat")
+            create_static_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.lib.hat")
 
             hat_package = load(f"test_acccgen/{package_name}.dyn.hat")
 

--- a/tools/test/test_hat.py
+++ b/tools/test/test_hat.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from hat import load
 from hat_to_dynamic import create_dynamic_package
+from hat_to_lib import create_static_lib_package
 
 class HAT_test(unittest.TestCase):
 
@@ -32,6 +33,8 @@ class HAT_test(unittest.TestCase):
             package.build(name=package_name, output_dir="test_acccgen", mode=mode)
 
             create_dynamic_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.dyn.hat")
+            create_static_library_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.lib.hat")
+
             hat_package = load(f"test_acccgen/{package_name}.dyn.hat")
 
             for name in hat_package.names:


### PR DESCRIPTION
* Add `hat_to_lib` which calls the Library Manager (Windows) or GNU archiver (Linux, macOS)
* Future work will support cross-compilation (via lld)