### PR TITLE
Update hat tools to consume dynamic HAT packages

### DIFF
--- a/tools/benchmark_hat_package.py
+++ b/tools/benchmark_hat_package.py
@@ -28,9 +28,7 @@ class Benchmark:
         A compilation toolchain in your PATH: cl.exe & link.exe (Windows), gcc (Linux), or clang (macOS)
     """
     def __init__(self, hat_path):
-        hat_path = Path(hat_path)
-        self.hat_path = hat_path.with_suffix(".dll.hat")
-        create_dynamic_package(str(hat_path), self.hat_path)
+        self.hat_path = Path(hat_path)
 
         self.hat_package = load(self.hat_path)
         self.hat_functions = self.hat_package.names

--- a/tools/test/test_benchmark_hat_package.py
+++ b/tools/test/test_benchmark_hat_package.py
@@ -23,7 +23,7 @@ class BenchmarkHATPackage_test(unittest.TestCase):
 
         package = acc.Package()
         package.add(nest, args=(A, B, C), base_name="test_function")
-        package.build(name="BenchmarkHATPackage_test_benchmark", output_dir="test_acccgen")
+        package.build(name="BenchmarkHATPackage_test_benchmark", output_dir="test_acccgen", format=acc.Package.Format.HAT_DYNAMIC)
 
         run_benchmark("test_acccgen/BenchmarkHATPackage_test_benchmark.hat", store_in_hat=False, batch_size=2, min_time_in_sec=1, input_sets_minimum_size_MB=1)
 

--- a/tools/test/test_hat.py
+++ b/tools/test/test_hat.py
@@ -33,7 +33,6 @@ class HAT_test(unittest.TestCase):
             package.build(name=package_name, output_dir="test_acccgen", mode=mode)
 
             create_dynamic_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.dyn.hat")
-            create_static_package(f"test_acccgen/{package_name}.hat", f"test_acccgen/{package_name}.lib.hat")
 
             hat_package = load(f"test_acccgen/{package_name}.dyn.hat")
 


### PR DESCRIPTION
Now that Accera can produce libs or dlls, HAT tools no longer need

For future work, we may consider adding a user-friendly way to query the type of HAT package (static lib, dynamic lib, static obj)