### PR TITLE
fix link target for function

### DIFF
--- a/tools/hat_file.py
+++ b/tools/hat_file.py
@@ -438,7 +438,7 @@ class HATFile:
         self.function_map = self._function_table.function_map
         for func in self.functions:
             func.hat_file = self
-            func.link_target = self.path / self.dependencies.link_target
+            func.link_target = Path(self.path).resolve().parent / self.dependencies.link_target
 
     def Serialize(self, filepath=None):
         """Serilizes the HATFile to disk using the file location specified by `filepath`.


### PR DESCRIPTION
fix link target for function because hat package is initialized with hatfile path instead of dirname

Before this PR, `func.link_target` was set to <hatfile absolute path>/*.a
This resulted in an error as there is no such path.
After this PR, `func.link_target` is set to <hatfile's dirname>/*.a