### PR TITLE
Fix benchmarking of multiple functions in the same hat file

### DIFF
--- a/hatlib/hat.py
+++ b/hatlib/hat.py
@@ -102,12 +102,9 @@ def hat_description_to_python_function(hat_description: hat_file.HATFile,
 
         launches = func_desc.get("launches")
         if not launches:
-
-            hat_arg_descriptions = func_desc["arguments"]
-            function_name = func_desc["name"]
             hat_library: ctypes.CDLL = hat_details.shared_lib
 
-            def f(function_name, *args):
+            def f(function_name, hat_arg_descriptions, *args):
                 # verify that the (numpy) input args match the description in
                 # the hat file
                 arg_infos = [ArgInfo(d) for d in hat_arg_descriptions]
@@ -122,7 +119,7 @@ def hat_description_to_python_function(hat_description: hat_file.HATFile,
                 # call the function in the hat package
                 hat_library[function_name](*hat_args)
 
-            yield func_name, partial(f, function_name)
+            yield func_name, partial(f, func_desc["name"], func_desc["arguments"])
 
         else:
             device_func = hat_description.get("device_functions",

--- a/hatlib/hat.py
+++ b/hatlib/hat.py
@@ -26,13 +26,11 @@ For example:
 """
 
 import ctypes
-import numpy as np
 import pathlib
 import sys
 import toml
 from collections import OrderedDict
-from dataclasses import dataclass
-from typing import Any, Tuple
+from functools import partial
 
 try:
     from . import hat_file
@@ -109,7 +107,7 @@ def hat_description_to_python_function(hat_description: hat_file.HATFile,
             function_name = func_desc["name"]
             hat_library: ctypes.CDLL = hat_details.shared_lib
 
-            def f(*args):
+            def f(function_name, *args):
                 # verify that the (numpy) input args match the description in
                 # the hat file
                 arg_infos = [ArgInfo(d) for d in hat_arg_descriptions]
@@ -124,7 +122,7 @@ def hat_description_to_python_function(hat_description: hat_file.HATFile,
                 # call the function in the hat package
                 hat_library[function_name](*hat_args)
 
-            yield func_name, f
+            yield func_name, partial(f, function_name)
 
         else:
             device_func = hat_description.get("device_functions",

--- a/hatlib/test/test_benchmark_hat_package.py
+++ b/hatlib/test/test_benchmark_hat_package.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import unittest
-import sys, os
+import os
+import sys
 import accera as acc
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
@@ -23,6 +24,36 @@ class BenchmarkHATPackage_test(unittest.TestCase):
 
         package = acc.Package()
         package.add(nest, args=(A, B, C), base_name="test_function")
+        package.build(name="BenchmarkHATPackage_test_benchmark",
+                      output_dir="test_acccgen",
+                      format=acc.Package.Format.HAT_DYNAMIC)
+
+        run_benchmark("test_acccgen/BenchmarkHATPackage_test_benchmark.hat",
+                      store_in_hat=False,
+                      batch_size=2,
+                      min_time_in_sec=1,
+                      input_sets_minimum_size_MB=1)
+
+    def test_benchmark_multiple_functions(self):
+        A = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
+        B = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
+        C = acc.Array(role=acc.Array.Role.INPUT_OUTPUT, shape=(256, 256))
+        D = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256)) # dummy argument
+
+        nest = acc.Nest(shape=(256, 256, 256))
+        i, j, k = nest.get_indices()
+
+        @nest.iteration_logic
+        def _():
+            C[i, j] += A[i, k] * B[k, j]
+
+        package = acc.Package()
+        package.add(nest, args=(A, B, C), base_name="test_function")
+
+        # add another function with a dummy argument - run_benchmark should be able to call it
+        # with the correct signature
+        package.add(nest, args=(A, B, C, D), base_name="test_function_dummy")
+
         package.build(name="BenchmarkHATPackage_test_benchmark",
                       output_dir="test_acccgen",
                       format=acc.Package.Format.HAT_DYNAMIC)


### PR DESCRIPTION
The capture for function_name is being overwritten if there are multiple functions being benchmarked.

Before the fix:
```
Benchmarking function: matmul_relu_fusion_naive_64a1f4d149d6f346
[Benchmarking] Using 27 input sets, each 3145728 bytes
[Benchmarking] Warming up for 5 iterations...
[Benchmarking] Timing for at least 5s and at least 5 iterations...
[Benchmarking] Mean duration per iteration: 0.02730914s  <-- actually calling matmul_relu_fusion_transformed_5e23ad255420696c

Benchmarking function: matmul_relu_fusion_transformed_5e23ad255420696c
[Benchmarking] Using 27 input sets, each 3145728 bytes
[Benchmarking] Warming up for 5 iterations...
[Benchmarking] Timing for at least 5s and at least 5 iterations...
[Benchmarking] Mean duration per iteration: 0.02665616s
```

After the fix:

```
Benchmarking function: matmul_relu_fusion_naive_64a1f4d149d6f346
[Benchmarking] Using 27 input sets, each 3145728 bytes
[Benchmarking] Warming up for 5 iterations...
[Benchmarking] Timing for at least 5s and at least 5 iterations...
[Benchmarking] Mean duration per iteration: 0.10668768s

Benchmarking function: matmul_relu_fusion_transformed_5e23ad255420696c
[Benchmarking] Using 27 input sets, each 3145728 bytes
[Benchmarking] Warming up for 5 iterations...
[Benchmarking] Timing for at least 5s and at least 5 iterations...
[Benchmarking] Mean duration per iteration: 0.02880869s
```