### PR TITLE
Fix shadowed time variable in benchmark_hat_package.py

### DIFF
--- a/hatlib/README.md
+++ b/hatlib/README.md
@@ -10,7 +10,7 @@ Usage:
     import hatlib as hat
 
     # load the package
-    package = hat.load("my_package.hat")
+    _, package = hat.load("my_package.hat")
 
     # print the function names
     for name in package.names():

--- a/hatlib/benchmark_hat_package.py
+++ b/hatlib/benchmark_hat_package.py
@@ -220,15 +220,14 @@ def run_benchmark(hat_path,
                 f"WARNING: Failed to run function {function_name}, skipping this benchmark."
             )
             results.append(
-             {
+            {
                 "function_name": function_name,
                 "mean": "-",
                 "median_of_means": "-",
                 "mean_of_small_means": "-",
                 "robust_mean": "-",
                 "min_of_means": "-",
-            }   
-            )
+            })
     return results
 
 

--- a/hatlib/benchmark_hat_package.py
+++ b/hatlib/benchmark_hat_package.py
@@ -5,9 +5,7 @@ import numpy as np
 import pandas as pd
 import sys
 import time
-import toml
 import traceback
-from pathlib import Path
 
 from .callable_func import CallableFunc
 from .hat_file import HATFile
@@ -73,7 +71,7 @@ class Benchmark:
                 _perf_counter = time.perf_counter
                 perf_counter_scale = 1
             def perf_counter():
-                return _perf_counter / perf_counter_scale
+                return _perf_counter() / perf_counter_scale
 
             return perf_counter
 

--- a/hatlib/benchmark_hat_package.py
+++ b/hatlib/benchmark_hat_package.py
@@ -219,8 +219,7 @@ def run_benchmark(hat_path,
             print(
                 f"WARNING: Failed to run function {function_name}, skipping this benchmark."
             )
-            results.append(
-            {
+            results.append({
                 "function_name": function_name,
                 "mean": "-",
                 "median_of_means": "-",

--- a/hatlib/benchmark_hat_package.py
+++ b/hatlib/benchmark_hat_package.py
@@ -140,8 +140,8 @@ class Benchmark:
 
             batch_timings_ms = benchmark_func.benchmark(warmup_iters=warmup_iterations, iters=min_timing_iterations, batch_size=batch_size, args=input_sets)
             batch_timings_secs = list(map(lambda t: t / 1000, batch_timings_ms))
-            time = sum(batch_timings_secs) / (min_timing_iterations * batch_size)
-            return time, batch_timings_secs
+            mean_timings = sum(batch_timings_secs) / (min_timing_iterations * batch_size)
+            return mean_timings, batch_timings_secs
 
 
 def write_runtime_to_hat_file(hat_path, function_name, mean_time_secs):

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 import unittest
-import os
-import sys
 import accera as acc
 from hatlib import run_benchmark
 
 
 class BenchmarkHATPackage_test(unittest.TestCase):
-
     def test_benchmark(self):
         A = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
         B = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 import accera as acc
+import numpy as np
 from hatlib import run_benchmark
 
 
@@ -30,7 +31,8 @@ class BenchmarkHATPackage_test(unittest.TestCase):
             min_time_in_sec=1,
             input_sets_minimum_size_MB=1
         )
-        self.assertIn('test_function', results[0]['function_name'])
+        self.assertIn("test_function", results[0]["function_name"])
+        self.assertEqual(type(results[0]["mean"]), np.float64)
 
     def test_benchmark_multiple_functions(self):
         A = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
@@ -63,8 +65,10 @@ class BenchmarkHATPackage_test(unittest.TestCase):
             min_time_in_sec=1,
             input_sets_minimum_size_MB=1
         )
-        self.assertIn('test_function', results[0]['function_name'])
-        self.assertIn('test_function_dummy', results[1]['function_name'])
+        self.assertIn("test_function", results[0]["function_name"])
+        self.assertIn("test_function_dummy", results[1]["function_name"])
+        for r in results:
+            self.assertEqual(type(r["mean"]), np.float64)
 
 
 if __name__ == '__main__':

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -23,13 +23,14 @@ class BenchmarkHATPackage_test(unittest.TestCase):
             name="BenchmarkHATPackage_test_benchmark", output_dir="test_acccgen", format=acc.Package.Format.HAT_DYNAMIC
         )
 
-        run_benchmark(
+        results = run_benchmark(
             "test_acccgen/BenchmarkHATPackage_test_benchmark.hat",
             store_in_hat=False,
             batch_size=2,
             min_time_in_sec=1,
             input_sets_minimum_size_MB=1
         )
+        self.assertIn('test_function', results[0]['function_name'])
 
     def test_benchmark_multiple_functions(self):
         A = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
@@ -55,13 +56,15 @@ class BenchmarkHATPackage_test(unittest.TestCase):
             name="BenchmarkHATPackage_test_benchmark", output_dir="test_acccgen", format=acc.Package.Format.HAT_DYNAMIC
         )
 
-        run_benchmark(
+        results = run_benchmark(
             "test_acccgen/BenchmarkHATPackage_test_benchmark.hat",
             store_in_hat=False,
             batch_size=2,
             min_time_in_sec=1,
             input_sets_minimum_size_MB=1
         )
+        self.assertIn('test_function', results[0]['function_name'])
+        self.assertIn('test_function_dummy', results[1]['function_name'])
 
 
 if __name__ == '__main__':

--- a/test/test_hat.py
+++ b/test/test_hat.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 import accera as acc
 import numpy as np
-import os
-import sys
 import unittest
-from hatlib import load, create_dynamic_package, create_static_package
+from hatlib import load, create_dynamic_package
 
 
 class HAT_test(unittest.TestCase):
-
     def test_load(self):
 
         # Generate a HAT package


### PR DESCRIPTION
* Python interpreter may confuse the local variable `time` with the global `time` module
* This was observed when running the quickstart.ipynb demo. CI tests didn't fail because exceptions were swallowed.
 
```
Traceback (most recent call last):
  File "/root/miniconda/envs/accera_py39/lib/python3.9/site-packages/hatlib/benchmark_hat_package.py", line 184, in run_benchmark
    _, batch_timings = benchmark.run(
  File "/root/miniconda/envs/accera_py39/lib/python3.9/site-packages/hatlib/benchmark_hat_package.py", line 57, in run
    mean_elapsed_time, batch_timings = self._profile(
  File "/root/miniconda/envs/accera_py39/lib/python3.9/site-packages/hatlib/benchmark_hat_package.py", line 98, in _profile
    perf_counter = get_perf_counter()
  File "/root/miniconda/envs/accera_py39/lib/python3.9/site-packages/hatlib/benchmark_hat_package.py", line 69, in get_perf_counter
    if hasattr(time, 'perf_counter_ns'):
NameError: free variable 'time' referenced before assignment in enclosing scope
```

* Fix the subsequent issue that was uncovered around perf_counters
```
Traceback (most recent call last):
  File "/root/hat/hatlib/benchmark_hat_package.py", line 184, in run_benchmark
    _, batch_timings = benchmark.run(
  File "/root/hat/hatlib/benchmark_hat_package.py", line 57, in run
    mean_elapsed_time, batch_timings = self._profile(
  File "/root/hat/hatlib/benchmark_hat_package.py", line 109, in _profile
    start_time_secs = perf_counter()
  File "/root/hat/hatlib/benchmark_hat_package.py", line 76, in perf_counter
    return _perf_counter / perf_counter_scale
TypeError: unsupported operand type(s) for /: 'builtin_function_or_method' and 'int'
```

* Update tests to verify that the benchmarking succeeded