### PR TITLE
Avoid printing null bytes in hiprtcGetProgramLog

### DIFF
--- a/hatlib/pyhip/hiprtc.py
+++ b/hatlib/pyhip/hiprtc.py
@@ -309,7 +309,7 @@ def hiprtcGetProgramLog(prog):
     log_size = ctypes.c_size_t()
     status = _libhiprtc.hiprtcGetProgramLogSize(prog, ctypes.byref(log_size))
     hiprtcCheckStatus(status)
-    if log_size > 1:  # only print if there is something to print (log_size=1 is a null byte)
+    if log_size.value > 1:  # only print if there is something to print (log_size=1 is a null byte)
         log = "0" * log_size.value
         e_log = log.encode('utf-8')
         status = _libhiprtc.hiprtcGetProgramLog(prog, e_log)

--- a/hatlib/pyhip/hiprtc.py
+++ b/hatlib/pyhip/hiprtc.py
@@ -309,7 +309,7 @@ def hiprtcGetProgramLog(prog):
     log_size = ctypes.c_size_t()
     status = _libhiprtc.hiprtcGetProgramLogSize(prog, ctypes.byref(log_size))
     hiprtcCheckStatus(status)
-    if status:  # only print if there is an error
+    if log_size > 1:  # only print if there is something to print (log_size=1 is a null byte)
         log = "0" * log_size.value
         e_log = log.encode('utf-8')
         status = _libhiprtc.hiprtcGetProgramLog(prog, e_log)

--- a/hatlib/pyhip/hiprtc.py
+++ b/hatlib/pyhip/hiprtc.py
@@ -309,14 +309,11 @@ def hiprtcGetProgramLog(prog):
     log_size = ctypes.c_size_t()
     status = _libhiprtc.hiprtcGetProgramLogSize(prog, ctypes.byref(log_size))
     hiprtcCheckStatus(status)
-    if log_size.value > 1:  # only print if there is something to print (log_size=1 is a null byte)
-        log = "0" * log_size.value
-        e_log = log.encode('utf-8')
-        status = _libhiprtc.hiprtcGetProgramLog(prog, e_log)
-        hiprtcCheckStatus(status)
-        return e_log.decode('utf-8')
-    else:
-        return ""
+    log = "0" * log_size.value
+    e_log = log.encode('utf-8')
+    status = _libhiprtc.hiprtcGetProgramLog(prog, e_log)
+    hiprtcCheckStatus(status)
+    return e_log.decode('utf-8')
 
 
 _libhiprtc.hiprtcGetCodeSize.restype = int

--- a/hatlib/rocm_loader.py
+++ b/hatlib/rocm_loader.py
@@ -27,7 +27,6 @@ def compile_rocm_program(rocm_src_path: pathlib.Path, func_name):
     )
     device_properties = hipGetDeviceProperties(0)
     hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}', '-D__HIP_PLATFORM_AMD__'])
-    print(hiprtcGetProgramLog(prog))
     code = hiprtcGetCode(prog)
 
     return code


### PR DESCRIPTION
hiprtcGetProgramLog should not be called if status == 0, as it cause null bytes to be printed to the console. This breaks tools such as pytest which save console output to XML.

See comment in #48 