### PR TITLE
Make run_benchmark raise exceptions instead of swallowing it

### DIFF
--- a/hatlib/benchmark_hat_package.py
+++ b/hatlib/benchmark_hat_package.py
@@ -217,23 +217,16 @@ def run_benchmark(hat_path,
                 "min_of_means": min_of_means,
             })
         except Exception as e:
-            exc_type, exc_val, exc_tb = sys.exc_info()
-            traceback.print_exception(exc_type,
-                                      exc_val,
-                                      exc_tb,
-                                      file=sys.stderr)
             if verbose:
+                exc_type, exc_val, exc_tb = sys.exc_info()
+                traceback.print_exception(exc_type,
+                                        exc_val,
+                                        exc_tb,
+                                        file=sys.stderr)
                 print("\nException message: ", e)
                 print(f"WARNING: Failed to run function {function_name}, skipping this benchmark.")
 
-            results.append({
-                "function_name": function_name,
-                "mean": "-",
-                "median_of_means": "-",
-                "mean_of_small_means": "-",
-                "robust_mean": "-",
-                "min_of_means": "-",
-            })
+            raise e
     return results
 
 


### PR DESCRIPTION
- run_benchmark should just raise exception instead of simply printing
- caller can deal with the exception how it wants to