### PR TITLE
Handle batch_size < 2 in mean of small means

### DIFF
--- a/hatlib/benchmark_hat_package.py
+++ b/hatlib/benchmark_hat_package.py
@@ -199,9 +199,8 @@ def run_benchmark(hat_path,
 
             mean_of_means = sorted_batch_means.mean()
             median_of_means = sorted_batch_means[num_batches // 2]
-            mean_of_small_means = sorted_batch_means[0:num_batches // 2].mean()
-            robust_means = sorted_batch_means[(num_batches //
-                                               5):(-num_batches // 5)]
+            mean_of_small_means = sorted_batch_means[0:max(1, num_batches // 2)].mean()
+            robust_means = sorted_batch_means[(num_batches // 5):(-num_batches // 5)]
             robust_mean_of_means = robust_means.mean()
             min_of_means = sorted_batch_means[0]
 


### PR DESCRIPTION
When batch_size == 1, array indexing does not work:

/usr/local/lib/python3.8/dist-packages/hatlib/benchmark_hat_package.py:202: RuntimeWarning: Mean of empty slice.
  mean_of_small_means = sorted_batch_means[0:num_batches // 2].mean()