### PR TITLE
switch to macos 12 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-12']
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fixes #62 

Accera binaries are now built using macos-12 (because LLVM binaries are built using macos-12). Therefore, upgrade hatlib's tests to use macos-12. 

This is only a test dependency for hatlib. Actual hatlib implementation is agnostic to the OS version.