### PR TITLE
Fixes for mixture of output and input_output parameters

### DIFF
--- a/hatlib/arg_value.py
+++ b/hatlib/arg_value.py
@@ -68,18 +68,24 @@ class ArgValue:
                 )
 
             if desc.is_constant_shaped:
-                # confirm that the arg shape is correct (numpy represents shapes as tuples)
-                desc_shape = tuple(map(int, desc.shape))
-                if desc_shape != self.value.shape:
-                    raise ValueError(
-                        f"expected argument to have shape={desc_shape} but received shape={self.value.shape}"
-                    )
+                if self.value.size > 1:
+                    # confirm that the arg shape is correct (numpy represents shapes as tuples)
+                    desc_shape = tuple(map(int, desc.shape))
+                    if desc_shape != self.value.shape:
+                        raise ValueError(
+                            f"expected argument to have shape={desc_shape} but received shape={self.value.shape}"
+                        )
 
-                # confirm that the arg strides are correct (numpy represents strides as tuples)
-                desc_numpy_strides = tuple(desc.numpy_strides) if hasattr(desc, 'numpy_strides') else tuple(map(lambda x: x * desc.element_num_bytes, desc_shape[1:] + (1,))) 
-                if desc_numpy_strides != self.value.strides:
+                    # confirm that the arg strides are correct (numpy represents strides as tuples)
+                    desc_numpy_strides = tuple(desc.numpy_strides) if hasattr(desc, 'numpy_strides') else tuple(map(lambda x: x * desc.element_num_bytes, desc_shape[1:] + (1,))) 
+                    if desc_numpy_strides != self.value.strides:
+                        raise ValueError(
+                            f"expected argument to have strides={desc_numpy_strides} but received strides={self.value.strides}"
+                        )
+                elif self.value.size != desc.total_element_count:
+                    # special casing for size=1 arrays
                     raise ValueError(
-                        f"expected argument to have strides={desc_numpy_strides} but received strides={self.value.strides}"
+                        f"expected argument to have size={desc.total_element_count} but received shape={self.value.size}"
                     )
         else:
             pass    # TODO - support other pointer levels

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -93,7 +93,7 @@ class FunctionInfo:
                         if expanded_args[i_dim] is None:  # arg not yet initialized
                             expanded_args[i_dim] = ArgValue(dim_arg_info, dim_val)
             elif hat_desc.logical_type == hat_file.ParameterType.AffineArray:
-                expanded_args[i] = array
+                expanded_args[i] = args[i_value]
                 i_value = i_value + 1
             # else hat_file.ParameterType.Element handled above
 

--- a/hatlib/hat_package.py
+++ b/hatlib/hat_package.py
@@ -48,6 +48,12 @@ class HATPackage:
 
         return list(filter(matches_target, all_functions))
 
+    def get_function(self, name: str) -> Function:
+        for f in self.get_functions():
+            if f.name == name:
+                return f
+        raise ModuleNotFoundError(f"Function {name} not found")
+
     def benchmark(
         self,
         functions: List[Function] = None,

--- a/hatlib/hat_package.py
+++ b/hatlib/hat_package.py
@@ -48,12 +48,6 @@ class HATPackage:
 
         return list(filter(matches_target, all_functions))
 
-    def get_function(self, name: str) -> Function:
-        for f in self.get_functions():
-            if f.name == name:
-                return f
-        raise ModuleNotFoundError(f"Function {name} not found")
-
     def benchmark(
         self,
         functions: List[Function] = None,

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -66,11 +66,14 @@ class BenchmarkHATPackage_test(unittest.TestCase):
             input_sets_minimum_size_MB=1
         )
 
-        func_names = [r.function_name for r in results]
+        def drop_hash_suffix(name: str) -> str:
+            return name[:name.rfind("_")]
+
+        func_names = [drop_hash_suffix(r.function_name) for r in results]
         self.assertIn("test_function", func_names)
         self.assertIn("test_function_dummy", func_names)
         for r in results:
-            self.assertEqual(type(r.mean), np.float64)
+            self.assertEqual(type(r.mean), np.float64
 
 
 if __name__ == '__main__':

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -65,8 +65,10 @@ class BenchmarkHATPackage_test(unittest.TestCase):
             min_time_in_sec=1,
             input_sets_minimum_size_MB=1
         )
-        self.assertIn("test_function", results[0].function_name)
-        self.assertIn("test_function_dummy", results[1].function_name)
+
+        func_names = [r.function_name for r in results]
+        self.assertIn("test_function", func_names)
+        self.assertIn("test_function_dummy", func_names)
         for r in results:
             self.assertEqual(type(r.mean), np.float64)
 

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -70,6 +70,7 @@ class BenchmarkHATPackage_test(unittest.TestCase):
         def drop_hash_suffix(name: str) -> str:
             return name[:name.rfind("_")]
 
+        # BUGBUG: shouldn't the order be based on package.add?
         func_names = [drop_hash_suffix(r.function_name) for r in results]
         self.assertIn("test_function", func_names)
         self.assertIn("test_function_dummy", func_names)

--- a/test/test_benchmark_hat_package.py
+++ b/test/test_benchmark_hat_package.py
@@ -6,6 +6,7 @@ from hatlib import run_benchmark
 
 
 class BenchmarkHATPackage_test(unittest.TestCase):
+
     def test_benchmark(self):
         A = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
         B = acc.Array(role=acc.Array.Role.INPUT, shape=(256, 256))
@@ -73,7 +74,7 @@ class BenchmarkHATPackage_test(unittest.TestCase):
         self.assertIn("test_function", func_names)
         self.assertIn("test_function_dummy", func_names)
         for r in results:
-            self.assertEqual(type(r.mean), np.float64
+            self.assertEqual(type(r.mean), np.float64)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes some issues when we have both dynamic and static-sized output arrays:
* input_output parameter is incorrectly copied during expansion
* handle size=1 input/output arrays in argument verification

Update benchmark tests to not expect a certain order of function enumeration