### PR TITLE
Add support for floating type arguments to hat functions

### DIFF
--- a/hatlib/arg_info.py
+++ b/hatlib/arg_info.py
@@ -93,7 +93,7 @@ class ArgInfo:
             self.shape = re.split(r"\s?\*\s?", param_description.size)
 
         elif param_description.logical_type == hat_file.ParameterType.Element:
-            if param_description.usage == hat_file.UsageType.Input or element_type == 'int64_t':
+            if param_description.usage == hat_file.UsageType.Input or (element_type == 'int64_t' and param_description.usage == hat_file.UsageType.InputOutput):
                 self.ctypes_type = ctypes_type
             else:
                 self.ctypes_type = ctypes.POINTER(ctypes_type)

--- a/hatlib/arg_info.py
+++ b/hatlib/arg_info.py
@@ -93,7 +93,7 @@ class ArgInfo:
             self.shape = re.split(r"\s?\*\s?", param_description.size)
 
         elif param_description.logical_type == hat_file.ParameterType.Element:
-            if param_description.usage == hat_file.UsageType.Input:
+            if param_description.usage == hat_file.UsageType.Input or element_type == 'int64_t':
                 self.ctypes_type = ctypes_type
             else:
                 self.ctypes_type = ctypes.POINTER(ctypes_type)

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -28,7 +28,7 @@ class FunctionInfo:
 
         for i, (info, value) in enumerate(zip(self.arguments, args)):
             try:
-                if isinstance(value, np.ndarray):
+                if isinstance(value, np.ndarray) or isinstance(value, np.int64):
                     value = ArgValue(info, value)
 
                 value.verify(info)
@@ -38,7 +38,7 @@ class FunctionInfo:
     def as_cargs(self, args: List[Any]):
         "Converts arguments to their C interfaces"
         arg_values = [
-            ArgValue(info, value) if isinstance(value, np.ndarray) else value
+            ArgValue(info, value) if isinstance(value, np.ndarray) or isinstance(value, np.int64) else value
             for info, value in zip(self.arguments, args)
         ]
 

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -138,13 +138,7 @@ class FunctionInfo:
 
         for i, (info, value) in enumerate(zip(self.arguments, args)):
             try:
-                if (
-                    isinstance(value, np.ndarray)
-                    or isinstance(value, np.int64)
-                    or isinstance(value, np.int32)
-                    or isinstance(value, np.int16)
-                    or isinstance(value, np.int8)
-                ):
+                if isinstance(value, np.ndarray) or issubclass(type(value), np.integer):
                     value = ArgValue(info, value)
 
                 value.verify(info)
@@ -158,10 +152,7 @@ class FunctionInfo:
         arg_values = [
             ArgValue(info, value)
             if isinstance(value, np.ndarray)
-            or isinstance(value, np.int64)
-            or isinstance(value, np.int32)
-            or isinstance(value, np.int16)
-            or isinstance(value, np.int8)
+            or issubclass(type(value), np.integer)
             else value
             for info, value in zip(self.arguments, args)
         ]

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -138,7 +138,7 @@ class FunctionInfo:
 
         for i, (info, value) in enumerate(zip(self.arguments, args)):
             try:
-                if isinstance(value, np.ndarray) or issubclass(type(value), np.integer):
+                if isinstance(value, np.ndarray) or issubclass(type(value), np.integer) or issubclass(type(value), np.floating):
                     value = ArgValue(info, value)
 
                 value.verify(info)
@@ -153,6 +153,7 @@ class FunctionInfo:
             ArgValue(info, value)
             if isinstance(value, np.ndarray)
             or issubclass(type(value), np.integer)
+            or issubclass(type(value), np.floating)
             else value
             for info, value in zip(self.arguments, args)
         ]

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -21,10 +21,10 @@ class FunctionInfo:
 
     def preprocess(self, args: List[Any]) -> List[ArgValue]:
         if len(args) >= len(self.arguments):
-            return args # pass-through
+            return args  # pass-through
 
         if any(not isinstance(value, np.ndarray) for value in args):
-            return args # pass-through
+            return args  # pass-through
 
         # len(values) < len(self.arguments) and we have numpy arrays
         # do a best effort parameter expansion based on hat metadata
@@ -33,12 +33,15 @@ class FunctionInfo:
 
         # determine if the caller is passing in all arrays as arguments (including outputs)
         # (useful for automation scenarios)
-        num_array_args = len(list(
-            filter(
-                lambda x: x.logical_type == hat_file.ParameterType.RuntimeArray or \
-                     x.logical_type == hat_file.ParameterType.AffineArray, self.desc.arguments
+        num_array_args = len(
+            list(
+                filter(
+                    lambda x: x.logical_type == hat_file.ParameterType.RuntimeArray
+                    or x.logical_type == hat_file.ParameterType.AffineArray,
+                    self.desc.arguments,
+                )
             )
-        ))
+        )
         has_full_array_args = num_array_args == len(args)
 
         # maps argument names to indices
@@ -50,7 +53,7 @@ class FunctionInfo:
                     expanded_args[i] = ArgValue(info)
                     expanded_args[i].dim_values = []
                     array_shape = info.shape
-                    if has_full_array_args: # skip over the output arg
+                    if has_full_array_args:  # skip over the output arg
                         i_value = i_value + 1
                 else:
                     array = args[i_value]
@@ -76,14 +79,14 @@ class FunctionInfo:
 
                     if hat_desc.usage == hat_file.UsageType.Output:
                         assert dim_hat_desc.usage == hat_file.UsageType.Output
-                        if expanded_args[i_dim] is None: # arg not yet initialized
+                        if expanded_args[i_dim] is None:  # arg not yet initialized
                             expanded_args[i_dim] = ArgValue(dim_arg_info)
                         # add a cross reference so that we can resolve shapes for the output array
                         # after the function is called
                         expanded_args[i].dim_values.append(expanded_args[i_dim])
                     else:
                         assert dim_hat_desc.usage == hat_file.UsageType.Input
-                        if expanded_args[i_dim] is None: # arg not yet initialized
+                        if expanded_args[i_dim] is None:  # arg not yet initialized
                             expanded_args[i_dim] = ArgValue(dim_arg_info, dim_val)
             elif hat_desc.logical_type == hat_file.ParameterType.AffineArray:
                 expanded_args[i] = array
@@ -91,24 +94,32 @@ class FunctionInfo:
             # else hat_file.ParameterType.Element handled above
 
         if any(a is None for a in expanded_args):
-            raise RuntimeError(f"Could not resolve some arguments for {self.name} (see arguments marked 'None'): {expanded_args}")
+            raise RuntimeError(
+                f"Could not resolve some arguments for {self.name} (see arguments marked 'None'): {expanded_args}"
+            )
 
         return expanded_args
 
     def postprocess(self, expanded_args: List[Any], caller_args: List[Any]) -> None:
         if len(expanded_args) == len(caller_args):
-            return # pass-through
+            return  # pass-through
 
         if any(not isinstance(value, np.ndarray) for value in caller_args):
-            return # pass-through
+            return  # pass-through
 
         results = []
 
         # extract output arrays from the expanded args and override caller args
         for hat_desc, expanded_arg in zip(self.desc.arguments, expanded_args):
-            if hat_desc.logical_type == hat_file.ParameterType.RuntimeArray and hat_desc.usage == hat_file.UsageType.Output:
+            if (
+                hat_desc.logical_type == hat_file.ParameterType.RuntimeArray
+                and hat_desc.usage == hat_file.UsageType.Output
+            ):
                 # resolve shape using the output dimensions
-                shape = [d.value[0] if isinstance(d, ArgValue) else d for d in expanded_arg.dim_values]
+                shape = [
+                    d.value[0] if isinstance(d, ArgValue) else d
+                    for d in expanded_arg.dim_values
+                ]
                 # override the output array argument for the caller
                 results.append(np.ctypeslib.as_array(expanded_arg.value, shape))
 
@@ -123,17 +134,31 @@ class FunctionInfo:
 
         for i, (info, value) in enumerate(zip(self.arguments, args)):
             try:
-                if isinstance(value, np.ndarray) or isinstance(value, np.int64):
+                if (
+                    isinstance(value, np.ndarray)
+                    or isinstance(value, np.int64)
+                    or isinstance(value, np.int32)
+                    or isinstance(value, np.int16)
+                    or isinstance(value, np.int8)
+                ):
                     value = ArgValue(info, value)
 
                 value.verify(info)
             except ValueError as v:
-                sys.exit(f"Error calling {self.name}(...): argument {i} failed verification: {v}")
+                sys.exit(
+                    f"Error calling {self.name}(...): argument {i} failed verification: {v}"
+                )
 
     def as_cargs(self, args: List[Any]):
         "Converts arguments to their C interfaces"
         arg_values = [
-            ArgValue(info, value) if isinstance(value, np.ndarray) or isinstance(value, np.int64) else value
+            ArgValue(info, value)
+            if isinstance(value, np.ndarray)
+            or isinstance(value, np.int64)
+            or isinstance(value, np.int32)
+            or isinstance(value, np.int16)
+            or isinstance(value, np.int8)
+            else value
             for info, value in zip(self.arguments, args)
         ]
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,3 @@
 accera
+accera-gpu
 tomlkit<0.11.5 # accera related


### PR DESCRIPTION
Hat lib needs to support floating type arguments, for example, range node implementation needs to use a few floating numbers as input arguments to calculate the size.