### PR TITLE
Minimal support for caller-allocated dynamic-shaped hat functions

### DIFF
--- a/hatlib/arg_info.py
+++ b/hatlib/arg_info.py
@@ -8,6 +8,7 @@ from . import hat_file
 
 # element_type : [ ctype, dtype_str ]
 ARG_TYPES = {
+    "bool": [ctypes.c_bool, "bool"],
     "int8_t": [ctypes.c_int8, "int8"],
     "int16_t": [ctypes.c_int16, "int16"],
     "int32_t": [ctypes.c_int32, "int32"],

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -62,7 +62,11 @@ class FunctionInfo:
                 else:
                     array = args[i_value]
                     if hat_desc.usage == hat_file.UsageType.InputOutput:
-                        assert array is not None and "two-pass-alloc NULL arrays are not yet supported"
+                        # TODO: support the first pass of the two-pass-alloc pattern where the caller
+                        # passes NULL for the dynamic InputOutput arrays to determine the shapes
+                        # to allocate. Currently we assume that the caller knows the shape through
+                        # some out-of-band means (such as model shape inference)
+                        assert array is not None, "two-pass-alloc NULL arrays are not yet supported"
 
                     expanded_args[i] = array
                     array_shape = array.shape

--- a/hatlib/function_info.py
+++ b/hatlib/function_info.py
@@ -61,6 +61,9 @@ class FunctionInfo:
                         i_value = i_value + 1
                 else:
                     array = args[i_value]
+                    if hat_desc.usage == hat_file.UsageType.InputOutput:
+                        assert array is not None and "two-pass-alloc NULL arrays are not yet supported"
+
                     expanded_args[i] = array
                     array_shape = array.shape
                     i_value = i_value + 1
@@ -82,12 +85,10 @@ class FunctionInfo:
                     assert dim_hat_desc.logical_type == hat_file.ParameterType.Element
 
                     # The two-pass alloc calling pattern:
-                    # 1. call the function with NULL array pointers to compute the shape of the runtime array
+                    # 1. call the function with NULL arrays to compute the shape of the runtime array
                     # 2. allocate the runtime array with the computed shape
                     # 3. call the function again with the allocated runtime array
                     # The runtime array is therefore Input_Output, with Output dimensions
-                    # TODO: currently only supports calling the function with known array sizes
-                    # Add support for calling the function with NULL array pointers
                     two_pass_alloc = hat_desc.usage == hat_file.UsageType.InputOutput \
                         and dim_hat_desc.usage == hat_file.UsageType.Output
 

--- a/hatlib/hat_package.py
+++ b/hatlib/hat_package.py
@@ -48,6 +48,12 @@ class HATPackage:
 
         return list(filter(matches_target, all_functions))
 
+    def get_function(self, name: str) -> Function:
+        for f in self.get_functions():
+            if f.name == name:
+                return f
+        raise ModuleNotFoundError(f"Error: Cannot find {name} in {self.name}")
+
     def benchmark(
         self,
         functions: List[Function] = None,

--- a/test/test_verify_hat.py
+++ b/test/test_verify_hat.py
@@ -184,10 +184,10 @@ DLL_EXPORT void Range(const int32_t start[1], const int32_t limit[1], const int3
     int32_t delta0;
     if (limit[0] < start[0]) {
         delta0 = delta[0] <= 0 ? delta[0] : -delta[0];
-        delta0 = delta0 == 0 ? -1 : delta[0];
+        delta0 = delta0 == 0 ? -1 : delta0;
     } else {
         delta0 = delta[0] >= 0 ? delta[0] : -delta[0];
-        delta0 = delta0 == 0 ? 1 : delta[0];
+        delta0 = delta0 == 0 ? 1 : delta0;
     }
     int32_t start0 = start[0];
     int32_t limit0 = limit[0];

--- a/test/test_verify_hat.py
+++ b/test/test_verify_hat.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import copy
 import hatlib as hat
 import numpy as np
 import os
@@ -531,7 +532,8 @@ void Add_partial_dynamic(const float* A, uint32_t A_dim0, const float* B, float*
         C_ref = A + B
 
         C = func_map.Add_partial_dynamic(A, B)
-        np.testing.assert_allclose(C, C_ref)
+        C_copy = copy.deepcopy(C)
+        np.testing.assert_allclose(C_copy, C_ref)
 
     def test_partial_dynamic_runtime_arrays_multi_output(self):
         impl_code = '''#include <stdint.h>
@@ -668,8 +670,10 @@ void Add_Sub_partial_dynamic(const float* A, uint32_t A_dim0, const float* B, fl
         D_ref = A - B
 
         C, D = func_map.Add_Sub_partial_dynamic(A, B)
-        np.testing.assert_allclose(C, C_ref)
-        np.testing.assert_allclose(D, D_ref)
+        C_copy = copy.deepcopy(C)
+        D_copy = copy.deepcopy(D)
+        np.testing.assert_allclose(C_copy, C_ref)
+        np.testing.assert_allclose(D_copy, D_ref)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Groundwork for verification and eventual benchmarking of caller-alloced dynamic shaped outputs.

After this change, the caller is still responsible for determining the size of the output. Typically this can be determined out-of-band in machine learning models (based on inspecting / inferring kernel shapes).

Also fix the computation of strides when not provided by hat metadata, which is the case for runtime arrays. 

Given a (3, 10, 5) runtime array of float32 elements:
- Before fix: stride is computed as (4x10, 4x5, 4) = (40, 20, 4)
- After fix: stride is now (4x10x5, 4x5, 4) = (200, 20, 4)

Future work:
* Update benchmark hat package to use this functionality. It may need the second item below.
* A future PR can add support for calling these hat functions with null ptrs.

