### PR TITLE
Fixes numerous issues for benchmarking

### DIFF
--- a/hatlib/callable_func.py
+++ b/hatlib/callable_func.py
@@ -48,3 +48,7 @@ class CallableFunc(ABC):
     @abstractmethod
     def cleanup_runtime(self, benchmark: bool):
         ...
+
+    @abstractmethod
+    def should_flush_cache(self) -> bool:
+        ...

--- a/hatlib/cuda_loader.py
+++ b/hatlib/cuda_loader.py
@@ -205,11 +205,11 @@ class CudaCallableFunc(CallableFunc):
         cuda.cuCtxDestroy(self.context)
 
     def init_main(self, benchmark: bool, warmup_iters=0, device_id: int = 0, args=[]):
-        self.func_info.verify(args)
+        self.func_info.verify(args[0])
         self.device_mem = allocate_cuda_mem(self.func_info.arguments)
 
         if not benchmark:
-            transfer_mem_host_to_cuda(device_args=self.device_mem, host_args=args, arg_infos=self.func_info.arguments)
+            transfer_mem_host_to_cuda(device_args=self.device_mem, host_args=args[0], arg_infos=self.func_info.arguments)
 
         self.ptrs = device_args_to_ptr_list(self.device_mem)
 
@@ -236,41 +236,41 @@ class CudaCallableFunc(CallableFunc):
                 ASSERT_DRV(err)
 
     def main(self, benchmark: bool, iters=1, batch_size=1, min_time_in_sec=0, args=[]) -> float:
-        batch_timings: List[float] = []
-        while True:
-            for _ in range(batch_size):
-                err, = cuda.cuEventRecord(self.start_event, 0)
-                ASSERT_DRV(err)
+        batch_timings_ms: List[float] = []
+        iterations = 1
+        min_time_in_ms = min_time_in_sec * 1000
+        while sum(batch_timings_ms) < min_time_in_ms or len(batch_timings_ms) >= batch_size:
+            err, = cuda.cuEventRecord(self.start_event, 0)
+            ASSERT_DRV(err)
 
-                for _ in range(iters):
-                    err, = cuda.cuLaunchKernel(
-                        self.kernel,
-                        *self.hat_func.launch_parameters,    # [ grid[x-z], block[x-z] ]
-                        self.hat_func.dynamic_shared_mem_bytes,
-                        0,    # stream
-                        self.ptrs.ctypes.data,    # kernel arguments
-                        0,    # extra (ignore)
-                    )
-
-                    if not benchmark:
-                        ASSERT_DRV(err)
-
-                err, = cuda.cuEventRecord(self.stop_event, 0)
-                ASSERT_DRV(err)
-                err, = cuda.cuEventSynchronize(self.stop_event)
-                ASSERT_DRV(err)
-                err, batch_time = cuda.cuEventElapsedTime(self.start_event, self.stop_event)
-                ASSERT_DRV(err)
-                batch_timings.append(batch_time)
+            for _ in range(iters):
+                err, = cuda.cuLaunchKernel(
+                    self.kernel,
+                    *self.hat_func.launch_parameters,    # [ grid[x-z], block[x-z] ]
+                    self.hat_func.dynamic_shared_mem_bytes,
+                    0,    # stream
+                    self.ptrs.ctypes.data,    # kernel arguments
+                    0,    # extra (ignore)
+                )
+                iterations += 1
 
                 if not benchmark:
-                    err, = cuda.cuCtxSynchronize()
                     ASSERT_DRV(err)
 
-            if sum(batch_timings) >= (min_time_in_sec * 1000):
-                break
+            err, = cuda.cuEventRecord(self.stop_event, 0)
+            ASSERT_DRV(err)
+            err, = cuda.cuEventSynchronize(self.stop_event)
+            ASSERT_DRV(err)
+            err, batch_time_ms = cuda.cuEventElapsedTime(self.start_event, self.stop_event)
+            ASSERT_DRV(err)
+            batch_timings_ms.append(batch_time_ms)
 
-        return batch_timings
+            if not benchmark:
+                err, = cuda.cuCtxSynchronize()
+                ASSERT_DRV(err)
+
+        mean_elapsed_time_ms = sum(batch_timings_ms) / iterations
+        return mean_elapsed_time_ms, batch_timings_ms
 
     def cleanup_main(self, benchmark: bool, args=[]):
         # If there's no device mem, that means allocation during initialization failed, which means nothing else needs to be cleaned up either
@@ -286,6 +286,9 @@ class CudaCallableFunc(CallableFunc):
 
         if self.stop_event:
             cuda.cuEventDestroy(self.stop_event)
+
+    def should_flush_cache(self) -> bool:
+        return False
 
 
 def create_loader_for_device_function(device_func: Function, hat_dir_path: str) -> CallableFunc:

--- a/hatlib/host_loader.py
+++ b/hatlib/host_loader.py
@@ -24,11 +24,9 @@ profiler_code = """
 DLL_EXPORT void timer({intput_args_decl}, double* timing)
 {
     auto start = std::chrono::high_resolution_clock::now();
-    // for (unsigned i = 0; i < 1000; ++i)
-        {func_to_profile}
+    {func_to_profile}
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double, std::milli> elapsed_ms = end - start;
-    // printf("%lf ms\\n", elapsed_ms.count());
     *timing += elapsed_ms.count(); 
 }
 """

--- a/hatlib/host_loader.py
+++ b/hatlib/host_loader.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from typing import List
+from typing import List, Tuple
 from .callable_func import CallableFunc
 from .hat_file import Function, HATFile, Declaration, Dependencies, CallingConventionType, Parameter, ParameterType, OperatingSystem, UsageType
 from .hat import load
@@ -13,6 +13,7 @@ profiler_code = """
 #undef TOML
 #include "{src_include}"
 #include <chrono>
+#include <cstdio>
 
 #ifdef _MSC_VER
 #define DLL_EXPORT extern "C" __declspec( dllexport )
@@ -23,10 +24,12 @@ profiler_code = """
 DLL_EXPORT void timer({intput_args_decl}, double* timing)
 {
     auto start = std::chrono::high_resolution_clock::now();
-    {func_to_profile}
+    // for (unsigned i = 0; i < 1000; ++i)
+        {func_to_profile}
     auto end = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double> elapsed_seconds = end - start;
-    *timing += elapsed_seconds.count() * 1000.0; // Time in milliseconds
+    std::chrono::duration<double, std::milli> elapsed_ms = end - start;
+    // printf("%lf ms\\n", elapsed_ms.count());
+    *timing += elapsed_ms.count(); 
 }
 """
 
@@ -106,30 +109,38 @@ class HostCallableFunc(CallableFunc):
 
 
     def init_main(self, benchmark: bool, warmup_iters=0, device_id: int = 0, args=[]):
-        self.func_info.verify(args)
+        self.func_info.verify(args[0])
 
         for _ in range(warmup_iters):
-            self.timer_func(*args, self.timing_arg_val)
+            for arg in args:
+                self.timer_func(*arg, self.timing_arg_val)
 
-    def main(self, benchmark: bool, iters=1, batch_size=1, min_time_in_sec=0, args=[]) -> float:
-        batch_timings: List[float] = []
-        while True:
-            for _ in range(batch_size):
-                self.timing_arg_val.value = np.zeros((1,))
+    def main(self, benchmark: bool, iters=1, batch_size=1, min_time_in_sec=0, args=[]) -> Tuple[float, float]:
+        batch_timings_ms: List[float] = []
+        i = 0
+        i_max = len(args)
+        iterations = 1
+        min_time_in_ms = min_time_in_sec * 1000
 
-                for _ in range(iters):
-                    self.timer_func(*args, self.timing_arg_val)
+        while sum(batch_timings_ms) < min_time_in_ms and len(batch_timings_ms) < batch_size:
+            self.timing_arg_val.value = np.zeros((1,))
 
-                batch_time = self.timing_arg_val.value
-                batch_timings.append(batch_time)
+            for _ in range(iters):
+                self.timer_func(*args[i], self.timing_arg_val)
+                i = iterations % i_max
+                iterations += 1
 
-            if sum(batch_timings) >= (min_time_in_sec * 1000):
-                break
+            batch_time_ms = float(self.timing_arg_val.value)
+            batch_timings_ms.append(batch_time_ms)
 
-        return batch_timings
+        mean_elapsed_time_ms = sum(batch_timings_ms) / (iterations * 1)
+        return mean_elapsed_time_ms, batch_timings_ms
 
     def cleanup_main(self, benchmark: bool, args=[]):
         pass
+
+    def should_flush_cache(self) -> bool:
+        return True
 
 
 def create_loader_for_host_function(host_func: Function, hat_dir_path: str):


### PR DESCRIPTION
* Batch size was used in place of number of iterations per batch size when averaging batch size results.
* C++ benchmarking was developed on top of CallableFunc, which was designed for devices where multiple input sets were not needed. C++ benchmarking on the CPU, at least, needs these multiple input sets. This change fixes this issue.
* Number of iterations per batch was added as a command line argument
* CallableFunc instances for devices that need cache flushing will have extra data generated for them